### PR TITLE
Add support for expanding singleton dimensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "0.1.3"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 
 [compat]
 BlockArrays = "1.3.0"
+Compat = "4.16.0"
 FillArrays = "1.13.0"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BroadcastMapConversion"
 uuid = "4a4adec5-520f-4750-bb37-d5e66b4ddeb2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [compat]
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -3,5 +3,11 @@ uuid = "4a4adec5-520f-4750-bb37-d5e66b4ddeb2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 version = "0.1.3"
 
+[deps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+
 [compat]
+BlockArrays = "1.3.0"
+FillArrays = "1.13.0"
 julia = "1.10"

--- a/src/BroadcastMapConversion.jl
+++ b/src/BroadcastMapConversion.jl
@@ -10,12 +10,18 @@ const WrappedScalarArgs = Union{AbstractArray{<:Any,0},Ref{<:Any}}
 
 # Get the arguments of the map expression that
 # is equivalent to the broadcast expression.
-function map_args(bc::Broadcasted, rest...)
-  return (map_args(bc.args...)..., map_args(rest...)...)
+function map_args(bc::Broadcasted)
+  return map_args_flatten(bc)
 end
-map_args(a::AbstractArray, rest...) = (a, map_args(rest...)...)
-map_args(a, rest...) = map_args(rest...)
-map_args() = ()
+
+function map_args_flatten(bc::Broadcasted, args_rest...)
+  return (map_args_flatten(bc.args...)..., map_args_flatten(args_rest...)...)
+end
+function map_args_flatten(arg1::AbstractArray, args_rest...)
+  return (arg1, map_args_flatten(args_rest...)...)
+end
+map_args_flatten(arg1, args_rest...) = map_args_flatten(args_rest...)
+map_args_flatten() = ()
 
 struct MapFunction{F,Args<:Tuple} <: Function
   f::F
@@ -27,14 +33,18 @@ struct Arg end
 # is equivalent to the broadcast expression.
 # Returns a `MapFunction`.
 function map_function(bc::Broadcasted)
-  args = map_function_tuple(bc.args)
-  return MapFunction(bc.f, args)
+  return map_function_arg(bc)
 end
-map_function_tuple(t::Tuple{}) = t
-map_function_tuple(t::Tuple) = (map_function(t[1]), map_function_tuple(Base.tail(t))...)
-map_function(a::WrappedScalarArgs) = a[]
-map_function(a::AbstractArray) = Arg()
-map_function(a) = a
+map_function_args(args::Tuple{}) = args
+function map_function_args(args::Tuple)
+  return (map_function_arg(args[1]), map_function_args(Base.tail(args))...)
+end
+function map_function_arg(bc::Broadcasted)
+  return MapFunction(bc.f, map_function_args(bc.args))
+end
+map_function_arg(a::WrappedScalarArgs) = a[]
+map_function_arg(a::AbstractArray) = Arg()
+map_function_arg(a) = a
 
 # Evaluate MapFunction
 (f::MapFunction)(args...) = apply(f, args)[1]
@@ -51,6 +61,21 @@ function apply_tuple(t::Tuple, args)
   return (t1, ttail...), newargs
 end
 
+is_map_expr_or_arg(arg::AbstractArray) = true
+is_map_expr_or_arg(arg::Any) = false
+function is_map_expr_or_arg(bc::Broadcasted)
+  return all(is_map_expr_or_arg, bc.args)
+end
+function is_map_expr(bc::Broadcasted)
+  return is_map_expr_or_arg(bc)
+end
+
+abstract type ExprStyle end
+struct MapExpr <: ExprStyle end
+struct NotMapExpr <: ExprStyle end
+
+ExprStyle(bc::Broadcasted) = is_map_expr(bc) ? MapExpr() : NotMapExpr()
+
 abstract type AbstractMapped <: Base.AbstractBroadcasted end
 
 struct Mapped{Style<:Union{Nothing,BroadcastStyle},Axes,F,Args<:Tuple} <: AbstractMapped
@@ -60,18 +85,27 @@ struct Mapped{Style<:Union{Nothing,BroadcastStyle},Axes,F,Args<:Tuple} <: Abstra
   axes::Axes
 end
 
+# SimpleTraits.trait(Tr{X})
+
 function Mapped(bc::Broadcasted)
+  return Mapped(ExprStyle(bc), bc)
+end
+function Mapped(::NotMapExpr, bc::Broadcasted)
   return Mapped(bc.style, map_function(bc), map_args(bc), bc.axes)
 end
+function Mapped(::MapExpr, bc::Broadcasted)
+  return Mapped(bc.style, bc.f, bc.args, bc.axes)
+end
+
 function Broadcast.Broadcasted(m::Mapped)
   return Broadcasted(m.style, m.f, m.args, m.axes)
 end
 
-# Convert `Broadcasted` to `Mapped` when `Broadcasted`
-# is known to already be a map expression.
-function map_broadcast_to_mapped(bc::Broadcasted)
-  return Mapped(bc.style, bc.f, bc.args, bc.axes)
-end
+## # Convert `Broadcasted` to `Mapped` when `Broadcasted`
+## # is known to already be a map expression.
+## function map_broadcast_to_mapped(bc::Broadcasted)
+##   return Mapped(bc.style, bc.f, bc.args, bc.axes)
+## end
 
 mapped(f, args...) = Mapped(broadcasted(f, args...))
 
@@ -88,6 +122,6 @@ function Base.copy(m::Mapped)
   return copyto!(similar(m, elt), m)
 end
 Base.copyto!(dest::AbstractArray, m::Mapped) = map!(m.f, dest, m.args...)
-Broadcast.instantiate(m::Mapped) = map_broadcast_to_mapped(instantiate(Broadcasted(m)))
+Broadcast.instantiate(m::Mapped) = Mapped(instantiate(Broadcasted(m)))
 
 end

--- a/src/BroadcastMapConversion.jl
+++ b/src/BroadcastMapConversion.jl
@@ -5,6 +5,7 @@ module BroadcastMapConversion
 
 using Base.Broadcast:
   Broadcast, BroadcastStyle, Broadcasted, broadcasted, combine_eltypes, instantiate
+using Compat: allequal
 
 const WrappedScalarArgs = Union{AbstractArray{<:Any,0},Ref{<:Any}}
 

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -32,6 +32,7 @@ using Test: @inferred, @test, @test_throws, @testset
   for (a, b) in (
     (randn(elt, 2, 2), randn(elt, 2)),
     (randn(elt, 2, 2), randn(elt, 1, 2)),
+    (randn(elt, 2, 1), randn(elt, 1, 2)),
     (randn(elt, 2, 2, 2), randn(elt, 2)),
     (randn(elt, 2, 2, 2), randn(elt, 1, 2)),
     (randn(elt, 2, 2, 2), randn(elt, 1, 1, 2)),

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1,6 +1,6 @@
 using Base.Broadcast: broadcasted
 using BroadcastMapConversion: Mapped, is_map_expr, mapped
-using Test: @inferred, @test, @testset
+using Test: @inferred, @test, @test_throws, @testset
 
 @testset "BroadcastMapConversion (eltype=$elt)" for elt in (
   Float32, Float64, Complex{Float32}, Complex{Float64}
@@ -27,4 +27,20 @@ using Test: @inferred, @test, @testset
     Broadcast.broadcasted(+, [2], Broadcast.broadcasted(sin, [2]))
   )
   @test @inferred !is_map_expr(Broadcast.broadcasted(+, 2, Broadcast.broadcasted(sin, [2])))
+
+  # Logic handling singleton dimensions in broadcasting.
+  for (a, b) in (
+    (randn(elt, 2, 2), randn(elt, 2)),
+    (randn(elt, 2, 2), randn(elt, 1, 2)),
+    (randn(elt, 2, 2, 2), randn(elt, 2)),
+    (randn(elt, 2, 2, 2), randn(elt, 1, 2)),
+    (randn(elt, 2, 2, 2), randn(elt, 1, 1, 2)),
+    (randn(elt, 2, 2, 2), randn(elt, 2, 2)),
+    (randn(elt, 2, 2, 2), randn(elt, 1, 2, 2)),
+  )
+    @test_throws DimensionMismatch mapped(+, a, b)
+    bc = broadcasted(+, a, b)
+    m = Mapped(bc)
+    @test copy(m) == copy(bc)
+  end
 end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1,6 +1,6 @@
 using Base.Broadcast: broadcasted
-using BroadcastMapConversion: Mapped, mapped
-using Test: @test, @testset
+using BroadcastMapConversion: Mapped, is_map_expr, mapped
+using Test: @inferred, @test, @testset
 
 @testset "BroadcastMapConversion (eltype=$elt)" for elt in (
   Float32, Float64, Complex{Float32}, Complex{Float64}
@@ -22,4 +22,9 @@ using Test: @test, @testset
     @test copyto!(similar(m, elt), m) ≈ ref
     @test copyto!(similar(m′, elt), m) ≈ ref
   end
+
+  @test @inferred is_map_expr(
+    Broadcast.broadcasted(+, [2], Broadcast.broadcasted(sin, [2]))
+  )
+  @test @inferred !is_map_expr(Broadcast.broadcasted(+, 2, Broadcast.broadcasted(sin, [2])))
 end


### PR DESCRIPTION
Broadcasting in Julia supports [expanding singleton dimensions](https://docs.julialang.org/en/v1/manual/arrays/#Broadcasting) to match a common size. Before this PR, when converting broadcasting expressions like:
```julia
julia> fill(1, 2, 2) .+ [1, 2]
2×2 Matrix{Int64}:
 2  2
 3  3
```
to map expressions, we didn't handle repeating over the singleton dimensions properly. This PR fixes that by creating map expressions that lazily repeat the smaller arrays using a combination of `FillArrays.Fill` and `BlockArrays.BlockArray`.

This PR also refactors some of the internals to hopefully make the logic a little clearer.